### PR TITLE
Add build and examples files watcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "devDependencies": {
         "@types/node": "^18.15.11",
         "@types/uuid": "9.0.1",
+        "chokidar": "^3.5.3",
+        "consola": "^3.2.3",
         "esbuild": "^0.17.14",
         "itsamatch": "^1.2.0",
         "typescript": "^5.3.3",
@@ -44,6 +46,76 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.17.14",
@@ -82,11 +154,136 @@
         "@esbuild/win32-x64": "0.17.14"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/itsamatch": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/itsamatch/-/itsamatch-1.2.0.tgz",
       "integrity": "sha512-FyvO4wHPOEjBb5de7ibyfAE/57X/pMROchvNccqxmUSyUPl3xuvbCzi0Gj4ubca3XHp6SUaOzzxSgN31HD9uJQ==",
       "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.3.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "esbuild src/main.ts --bundle --outfile=build/poy.js --platform=node",
-    "watch": "esbuild src/main.ts --bundle --outfile=build/poy.js --platform=node --sourcemap --watch"
+    "watch": "esbuild src/main.ts --bundle --outfile=build/poy.js --platform=node --sourcemap --watch",
+    "start": "node watch.mjs"
   },
   "author": "Nathan Soufflet",
   "license": "MIT",
@@ -17,6 +18,8 @@
   "devDependencies": {
     "@types/node": "^18.15.11",
     "@types/uuid": "9.0.1",
+    "chokidar": "^3.5.3",
+    "consola": "^3.2.3",
     "esbuild": "^0.17.14",
     "itsamatch": "^1.2.0",
     "typescript": "^5.3.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,13 @@
 
 export const config = {
-    maxReductionSteps: 1_000_000_000,
-    requireExplicitTypeParameters: false,
-    debug: {
-        unification: false,
-        ignoreTypeParamName: true,
-        extensionType: true,
-    },
-};
+  defaultTestFile: './examples/Lab.poy',
+
+  maxReductionSteps: 1_000_000_000,
+  maxUnificationSteps: 100,
+  requireExplicitTypeParameters: false,
+  debug: {
+    unification: false,
+    ignoreTypeParamName: true,
+    extensionType: true,
+  },
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,31 +1,48 @@
-import { bundle } from "./bundle/bundle";
-import { createFileSystem, type FileSystem } from "./misc/fs";
-import { Resolver } from "./resolve/resolve";
+import { bundle } from "./bundle/bundle"
+import { createFileSystem, type FileSystem } from "./misc/fs"
+import { Resolver } from "./resolve/resolve"
+import { rainbowstrip, clr } from './misc/colors'
+import { config } from './config'
 
 async function compile(sourceFile: string, fs: FileSystem): Promise<string> {
-    const resolver = new Resolver(fs);
-    await resolver.resolve(sourceFile);
-    return bundle(resolver.modules);
+  const resolver = new Resolver(fs)
+  await resolver.resolve(sourceFile)
+  return bundle(resolver.modules)
 }
 
 async function main() {
-    const fs = await createFileSystem();
-    const args = process.argv.slice(2);
-    const sourceFile = args[0];
-    const outFile = args[1];
+  const time = performance.now()
 
-    if (sourceFile === undefined) {
-        console.error('Usage: poy <source-file> [output-file]');
-        process.exit(1);
-    }
+  const fs = await createFileSystem()
+  const args = process.argv.slice(2)
+  const sourceFile = args[0] ?? config.defaultTestFile
+  const outFile = args[1]
 
-    const output = await compile(sourceFile, fs);
+  if (sourceFile === undefined) {
+    console.error('Usage: poy <source-file> [output-file]')
+    process.exit(1)
+  }
 
-    if (outFile === undefined) {
-        console.log(output);
-    } else {
-        await fs.writeFile(outFile, output);
-    }
+  // -- header --
+  console.log('Compiler started')
+  console.clear() // clear doesnt work properly unless there's a console.log before it
+
+  console.log(clr.gray('Compiling: ') + sourceFile)
+  console.log(rainbowstrip(8))
+  console.log()
+  // -- header --
+
+  const output = await compile(sourceFile, fs)
+
+  if (outFile === undefined) {
+    console.log(output)
+  } else {
+    await fs.writeFile(outFile, output)
+  }
+
+  // -- footer --
+  console.log()
+  console.log(clr.greenBright(`──────[ completed in ${((performance.now() - time).toFixed(2))} ms ]──────`))
 }
 
-main();
+main()

--- a/src/misc/colors.ts
+++ b/src/misc/colors.ts
@@ -1,0 +1,5 @@
+import { colors } from 'consola/utils'
+
+export { colors as clr }
+
+export const rainbowstrip = (size = 5) => [colors.red, colors.yellow, colors.green, colors.blue, colors.magenta, colors.cyan].map((clr, i) => clr('▃'.repeat(size))).join('')

--- a/watch.mjs
+++ b/watch.mjs
@@ -1,0 +1,130 @@
+import { exec, execSync } from 'node:child_process'
+import chokidar from 'chokidar'
+import consola from 'consola'
+import { colors } from 'consola/utils'
+
+const EXAMPLES_EXT = '.poy' // it will remember the last file with this extension
+const WATCH_PATTERN = [
+  './build/**/*.js',
+  './examples/*.poy',
+]
+const BUILD_WATCHER_COMMAND = 'npm run watch --silent'
+const RUN_ON_CHANGE_COMMAND = 'node --enable-source-maps ./build/poy.js' // example file is appended to this command
+
+consola.box('Compiler & Tests Watcher')
+// ----------------------------------------------------------------------
+consola.start(colors.gray('Watch starting'))
+runRaw(BUILD_WATCHER_COMMAND, { async: true })
+consola.ready('Watch started')
+// ----------------------------------------------------------------------
+watcher({
+  pattern: WATCH_PATTERN,
+  onSuccess: execute,
+})
+
+// ----------------------------------------------------------------------
+let exampleFile = ''
+
+function overrideLastLine() {
+  process.stdout.moveCursor(0, -1) // up one line
+  process.stdout.clearLine(1) // from cursor to end
+}
+
+function watcher({ pattern = '', onSuccess = () => { } }) {
+  const opts = {
+    ignored: /node_modules|\.git/,
+    persistent: true,
+    followSymlinks: false,
+  }
+  let firstRun = true, delayedExecute = false
+  setTimeout(() => {
+    firstRun = false
+    if (delayedExecute) onSuccess()
+  }, 2000)
+
+  chokidar.watch(pattern, opts)
+    .on('change', (event, path) => {
+      // consola.log(event)
+      if (event.endsWith(EXAMPLES_EXT)) exampleFile = event
+      if (!firstRun) {
+        overrideLastLine()
+        consola.info(event)
+        onSuccess()
+      } else {
+        delayedExecute = true
+      }
+    })
+    .on('ready', () => {
+      consola.ready('Chokidar ready')
+      if (!firstRun) {
+        onSuccess()
+      } else {
+        delayedExecute = true
+      }
+    }).on('error', (error) => {
+      if (firstRun) delayedExecute = false
+      consola.error(error)
+    })
+}
+
+const run = debounce(runRaw, 100)
+
+let building = false
+function execute() {
+  if (building) {
+    overrideLastLine()
+    consola.log(colors.gray('Skip due to building in progress...'))
+    return
+  }
+  building = true
+  overrideLastLine()
+  consola.start('Running...', exampleFile)
+  run(RUN_ON_CHANGE_COMMAND + ' ' + exampleFile, false, () => {
+    building = false
+  })
+}
+
+function runRaw(command, { async = false }, onExit = () => { }) {
+  try {
+    let proc
+    if (async) {
+      proc = exec(command, { stdio: 'inherit' })
+
+      proc.on('close', (code) => {
+        consola.success(command + `: exited with ${code}`)
+        onExit()
+      })
+      proc.stdout.on('data', (x) => {
+        overrideLastLine()
+        process.stdout.write(x)
+      })
+      proc.stderr.on('data', (x) => {
+        process.stderr.write(x)
+      })
+    } else {
+      proc = execSync(command, { stdio: 'inherit' })
+      onExit()
+    }
+
+    consola.success(colors.gray('Run finished: ' + command))
+  } catch (e) {
+    consola.fail('Run failed:', command)
+    onExit()
+  }
+  consola.log(colors.gray('Waiting for changes...'))
+}
+
+function debounce(func, wait = 1000, immediate = false) {
+  let timeout
+  return function () {
+    const context = this, args = arguments
+    const later = function () {
+      timeout = null
+      if (!immediate) func.apply(context, args)
+    }
+    const callNow = immediate && !timeout
+    clearTimeout(timeout)
+    timeout = setTimeout(later, wait)
+    if (callNow) func.apply(context, args)
+  }
+}

--- a/watch.mjs
+++ b/watch.mjs
@@ -9,7 +9,7 @@ const WATCH_PATTERN = [
   './examples/*.poy',
 ]
 const BUILD_WATCHER_COMMAND = 'npm run watch --silent'
-const RUN_ON_CHANGE_COMMAND = 'node --enable-source-maps ./build/poy.js' // example file is appended to this command
+const RUN_ON_CHANGE_COMMAND = 'node --enable-source-maps ./build/poy.js {file}' // {file} is replaced by last example file
 
 consola.box('Compiler & Tests Watcher')
 // ----------------------------------------------------------------------
@@ -79,7 +79,7 @@ function execute() {
   building = true
   overrideLastLine()
   consola.start('Running...', exampleFile)
-  run(RUN_ON_CHANGE_COMMAND + ' ' + exampleFile, false, () => {
+  run(RUN_ON_CHANGE_COMMAND.replace('{file}', exampleFile), false, () => {
     building = false
   })
 }


### PR DESCRIPTION
![Code_hlpQqNA13R](https://github.com/nathsou/poy/assets/181384/b90764e4-409a-44ea-bcf2-63fee947651f)

> `npm start` 

Guaranteed to improve your dev experience 😉 

* Runs watch command + using chokidar monitors any `build/**/*.js` and `examples/*.poy` file changes. 
* Also remembers latest changed `.poy` example file
  * if you want to run any example you can just Ctrl+S on any example and it will run on it (even when having no changes).

For some reason esbuild fails to display colors for its errors when run through this script, I'm using swc for my own version which doesn't have this issue.