### PR TITLE
Add simple test scopes for checking type inference failures

### DIFF
--- a/examples/TestEx.poy
+++ b/examples/TestEx.poy
@@ -1,0 +1,28 @@
+
+test NAMED {
+  mut a = 1
+  a = 2
+}
+
+
+test {
+  mut a = 1
+  a = 2
+}
+
+
+test FAIL {
+  let a = 1
+  a = 2
+}
+
+
+test YAY {
+  mut a = 1
+  a = 2
+
+  test FAIL {
+    let a = 1
+    a = 2
+  }
+}

--- a/src/ast/sweet/decl.ts
+++ b/src/ast/sweet/decl.ts
@@ -18,11 +18,12 @@ export type Decl = DataType<{
     Struct: StructDecl,
     Extend: ExtendDecl,
     Enum: EnumDecl,
+    TestModule: { name: string, path: string, decls: Decl[], fail: boolean, succeeded: boolean },
     _Many: { decls: Decl[] },
 }>;
 
 export const Decl = {
-    ...genConstructors<Decl>(['Module', 'Import', 'Type', 'Struct', 'Extend', 'Enum', '_Many']),
+    ...genConstructors<Decl>(['Module', 'TestModule', 'Import', 'Type', 'Struct', 'Extend', 'Enum', '_Many']),
     Stmt: (stmt: Stmt) => ({ variant: 'Stmt', stmt }) satisfies Decl,
     Declare: (sig: Signature, attrs: Attributes) => ({ variant: 'Declare', sig, attrs }) satisfies Decl,
 };

--- a/src/codegen/bitter/decl.ts
+++ b/src/codegen/bitter/decl.ts
@@ -45,5 +45,24 @@ export const bitterDeclsOf = (sweet: SweetDecl): BitterDecl[] => match(sweet, {
         return [BitterDecl.Extend({ subject, uuid, decls: filteredDecls })];
     },
     Enum: ({ pub, name, variants }) => [BitterDecl.Enum({ pub, name, variants })],
+    TestModule: (mod) => {
+      // These lines are used to mark the start and end of a test module
+      // in the generated code. This allows the test runner to find each test,
+      // and create separate test cases for each while leaving the rest of the code intact.
+
+      // const start = BitterDecl.Comment(`---> TEST:${mod.name} FAILED at: ${mod.path}`)
+      // const end = BitterDecl.Comment(`<--- end of TEST:${mod.name}`)
+      if (!mod.succeeded) {
+        return []
+        // return [start, end]
+      }
+      const val = BitterDecl.Module({
+        name:  mod.name,
+        decls: mod.decls.flatMap(bitterDeclsOf),
+      })
+
+      return [val]
+      // return [end, val, end]
+    },
     _Many: ({ decls }) => decls.flatMap(bitterDeclsOf),
 });

--- a/src/parse/token.ts
+++ b/src/parse/token.ts
@@ -62,7 +62,7 @@ export type Symbol = UnaryOp | BinaryOp | AssignmentOp | Punctuation;
 const keywords = [
     'module', 'let', 'mut', 'fun', 'if', 'else', 'match', 'for', 'while',
     'return', 'break', 'type', 'enum', 'struct', 'interface', 'extend', 'use', 'in',
-    'declare', 'import', 'pub', 'static', 'or', 'and', 'yield',
+    'declare', 'import', 'pub', 'static', 'or', 'and', 'yield', 'test'
 ] as const;
 
 export type Keyword = typeof keywords[number];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
-    "compilerOptions": {
-        "module": "ES2020",
-        "target": "ES2020",
-        "strict": true,
-        "esModuleInterop": true,
-        "moduleResolution": "node",
-        "noEmit": true,
-    },
-    "exclude": [
-        "node_modules"
-    ]
+  "compilerOptions": {
+    "module": "ES2022",
+    "target": "ES2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "noEmit": true,
+  },
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
I ported back a simple version of `test optionalName { ... }` scopes, including an example file. 

Test declaration is simply a copy of module as its behavior requirements fit well, which is why it's called TestModule. 
When name is not set, we generate a new test_randomId name. It can also be set to "FAIL" (`test FAIL { .. }`) which passes when infer fails parsing the code.

Failed tests do not print code as we can no longer guarantee types being present.

**In my implementation,** the surrounding comments (which I left in, but commented out) are used to create individual tests, which keeps all the surrounding non-test-scoped code but only one includes one test declaration. So a file with multiple tests would generate and compile multiple versions of the same source and evaluate them one by one. Test comments also include source location so that the test runner doesn't have to interact with the compiler.

Sorry about the formatting, my default formatter is quite different so I had to disable it and manually adjust things.