### PR TITLE
Normalize directory path for module names

### DIFF
--- a/src/misc/fs.ts
+++ b/src/misc/fs.ts
@@ -1,4 +1,4 @@
-import { panic } from './utils.js'
+import { panic } from './utils'
 
 export type FileSystem = {
   readFile: (path: string) => Promise<string>

--- a/src/misc/fs.ts
+++ b/src/misc/fs.ts
@@ -1,32 +1,41 @@
-import { panic } from './utils';
+import { panic } from './utils.js'
 
 export type FileSystem = {
-    readFile: (path: string) => Promise<string>;
-    writeFile: (path: string, content: string) => Promise<void>;
-    absolutePath: (relativePath: string) => string;
-    directoryName: (path: string) => string;
-    join: (...paths: string[]) => string;
-};
+  readFile: (path: string) => Promise<string>
+  writeFile: (path: string, content: string) => Promise<void>
+  absolutePath: (relativePath: string) => string
+  directoryName: (path: string) => string
+  join: (...paths: string[]) => string
+  normalize: (path: string) => string
+}
 
 export async function createFileSystem(): Promise<FileSystem> {
-    if (global?.process?.versions?.node != null) {
-        const { readFile, writeFile } = await import('fs/promises');
-        const { resolve, dirname, join } = await import('path');
+  if (global?.process?.versions?.node != null) {
+    const { lstatSync } = await import('fs')
+    const { readFile, writeFile } = await import('fs/promises')
+    const { resolve, dirname, join, sep } = await import('path')
 
-        return {
-            readFile: path => readFile(path, 'utf8'),
-            writeFile: (path, content) => writeFile(path, content, 'utf8'),
-            absolutePath: relativePath => resolve(relativePath),
-            directoryName: path => dirname(path),
-            join: (...paths) => join(...paths),
-        };
-    } else {
-        return {
-            readFile: () => Promise.reject('Not implemented'),
-            writeFile: () => Promise.reject('Not implemented'),
-            absolutePath: () => panic('Not implemented'),
-            directoryName: () => panic('Not implemented'),
-            join: () => panic('Not implemented'),
-        };
+    return {
+      readFile: path => readFile(path, 'utf8'),
+      writeFile: (path, content) => writeFile(path, content, 'utf8'),
+      absolutePath: relativePath => resolve(relativePath),
+      directoryName: path => dirname(path),
+      join: (...paths) => join(...paths),
+      normalize: (path) => {
+        if (lstatSync(path).isDirectory()) {
+          panic('Cannot link a directory: ' + path)
+        }
+        return path.split(sep).join('/')
+      },
     }
+  } else {
+    return {
+      readFile: () => Promise.reject('Not implemented'),
+      writeFile: () => Promise.reject('Not implemented'),
+      absolutePath: () => panic('Not implemented'),
+      directoryName: () => panic('Not implemented'),
+      join: () => panic('Not implemented'),
+      normalize: () => panic('Not implemented'),
+    }
+  }
 }

--- a/src/resolve/resolve.ts
+++ b/src/resolve/resolve.ts
@@ -42,7 +42,7 @@ export class Resolver {
             const source = await this.fs.readFile(absolutePath);
             const tokens = lex(source);
             const newlines = indices(source.split(''), c => c === '\n');
-            const moduleName = camelCase(last(absolutePath.split('/')).split('.')[0]);
+            const moduleName = camelCase(last(this.fs.normalize(absolutePath).split('/')).split('.')[0])
             const topModule = parse(tokens, newlines, absolutePath).topModule(moduleName);
             const env = new TypeEnv(this, absolutePath, moduleName);
 


### PR DESCRIPTION
Fixes the issue as seen in the picture of the following PR: https://github.com/nathsou/poy/pull/3

Windows really likes having having different path separators depending on the locale, but we don't.